### PR TITLE
Fix Tuple import in GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -6,7 +6,7 @@ import sys
 import os
 from pathlib import Path
 from datetime import datetime
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Tuple
 
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,


### PR DESCRIPTION
## Summary
- add missing Tuple import in `gui.py`

## Testing
- `ruff check gui.py | grep F821 || echo "no F821"`
- `python gui.py` *(fails: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688682d6cfc8832cbbb2a2245cc1d16e