### PR TITLE
Add flexible column mapping

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -195,13 +195,13 @@ class BatchMappingDialog(QDialog):
         return source_cols, target_cols
 
     def parse_column_range(self, text: str) -> List[str]:
-        text = text.strip().upper()
-        if '-' in text and ',' not in text:
+        text = text.strip()
+        if '-' in text and ',' not in text and text.replace('-', '').isalpha():
             parts = text.split('-')
             if len(parts) != 2:
                 raise ValueError(f"Неверный диапазон: {text}")
-            start_col = parts[0].strip()
-            end_col = parts[1].strip()
+            start_col = parts[0].strip().upper()
+            end_col = parts[1].strip().upper()
             if not start_col.isalpha() or not end_col.isalpha():
                 raise ValueError(f"Неверные колонки: {text}")
             start_ord = ord(start_col)
@@ -210,10 +210,7 @@ class BatchMappingDialog(QDialog):
                 raise ValueError(f"Неверный диапазон: {text}")
             return [chr(i) for i in range(start_ord, end_ord + 1)]
         else:
-            cols = [col.strip() for col in text.split(',')]
-            for col in cols:
-                if not col.isalpha():
-                    raise ValueError(f"Неверная колонка: {col}")
+            cols = [col.strip() for col in text.split(',') if col.strip()]
             return cols
 
 


### PR DESCRIPTION
## Summary
- allow configuring column mapping using column indices or headers
- support resolving Excel and Google Sheet headers for mapping
- relax column format validation so names can be used

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6887ece6574c832ca48a8409e0518497